### PR TITLE
[RFR] Uses Accounts.oauth.serviceNames() to get the list of oauth services available

### DIFF
--- a/accounts-merge-client.js
+++ b/accounts-merge-client.js
@@ -1,22 +1,24 @@
-Meteor.signInWithFacebook = function (options, callback) {
-  Meteor.signInWithExternalService ('loginWithFacebook', options, callback);
-};
+function capitalizeWord(word) {
+  return word.charAt(0).toUpperCase() + word.slice(1)
+}
 
-Meteor.signInWithTwitter = function (options, callback) {
-  Meteor.signInWithExternalService ('loginWithTwitter', options, callback);
-};
+function createMethodForService(service) {
+  // Capitalize the first letter of the service name
+  var serviceName = capitalizeWord(service)
 
-Meteor.signInWithGoogle = function (options, callback) {
-  Meteor.signInWithExternalService ('loginWithGoogle', options, callback);
-};
+  // Register a meteor method for this service
+  Meteor['signInWith' + serviceName] = function(options, callback) {
+    Meteor.signInWithExternalService ('loginWith' + serviceName, options, callback);
+  }
+}
 
-Meteor.signInWithLinkedin = function (options, callback) {
-  Meteor.signInWithExternalService ('loginWithLinkedin', options, callback);
-};
+Meteor.startup(function(){
+  // Get the names of the registered oauth services from the Accounts package
+  var services = Accounts.oauth.serviceNames();
 
-Meteor.signInWithGithub = function (options, callback) {
-  Meteor.signInWithExternalService ('loginWithGithub', options, callback);
-};
+  // Create a meteor method for each service
+  _.each(services, createMethodForService);
+});
 
 Meteor.signInWithExternalService = function (service, options, callback) {
 

--- a/accounts-merge-server.js
+++ b/accounts-merge-server.js
@@ -19,7 +19,7 @@ Meteor.methods({
     var oldAccount = Meteor.users.findOne(oldAccountId);
     var newAccount = Meteor.users.findOne(this.userId);
 
-    _services = [ "facebook", "twitter", "google", "linkedin", "github" ];
+    _services = Accounts.oauth.serviceNames();
 
     // Move login services from loosing to winning user
     for (i=0; i<_services.length; i++) {

--- a/accounts-merge-server.js
+++ b/accounts-merge-server.js
@@ -19,6 +19,7 @@ Meteor.methods({
     var oldAccount = Meteor.users.findOne(oldAccountId);
     var newAccount = Meteor.users.findOne(this.userId);
 
+    // Get the names of the registered oauth services from the Accounts package
     _services = Accounts.oauth.serviceNames();
 
     // Move login services from loosing to winning user

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'mikael:accounts-merge',
-  version: '0.0.8',
+  version: '0.0.9',
   summary: 'Multiple login services for Meteor accounts',
   git: 'https://github.com/lirbank/meteor-accounts-merge.git',
   documentation: 'README.md'


### PR DESCRIPTION
Instead of having the oauth services hard coded, uses `Accounts.oauth.serviceNames()` to get the list of available services for the current application