### PR TITLE
Set profile name only when empty

### DIFF
--- a/accounts-merge-server.js
+++ b/accounts-merge-server.js
@@ -41,7 +41,7 @@ Meteor.methods({
         // Also add the profile.name from the new service.
         query = {};
         query['services.'+_services[i]] = newAccount.services[_services[i]];
-        query['profile.name'] = newAccount.profile.name;
+        if( !oldAccount.profile || !oldAccount.profile.name ) query['profile.name'] = newAccount.profile.name;
         try {
           Meteor.users.update (oldAccountId, {$set: query});
         } catch (e) {


### PR DESCRIPTION
fixes issue #25
tested it with:
 - winning's profile.name set                        -->   winning's name stays
 - winning's profile.name empty ("")             -->   loser's name copied in winning's profile
 - winning's profile.name not existing           -->   loser's name copied in winning's profile
 - winning's profile not existing                     -->   loser's name copied in winning's profile